### PR TITLE
Table expects an array, default is object.

### DIFF
--- a/js/src/components/app.js
+++ b/js/src/components/app.js
@@ -9,7 +9,7 @@ const dblogEndpointUrl = `${window.location.origin}${drupalSettings.path.baseUrl
 
 export default class App extends Component {
   state = {
-    data: {},
+    data: [],
     loaded: false,
     buttonDisabled: false,
     page: 0,


### PR DESCRIPTION
Was playing around with this. `Table` expects an array so it can perform `.map`, which is not possible on an object.